### PR TITLE
Hidden activity items not displayed in 'My Groups' activity scope

### DIFF
--- a/includes/hooks-buddypress-group.php
+++ b/includes/hooks-buddypress-group.php
@@ -268,7 +268,9 @@ function cacsp_filter_activity_args_for_groups( $args ) {
 	// Distinguish single group streams from "my groups".
 	if ( ! empty( $args['primary_id'] ) ) {
 		$group_ids = array( (int) $args['primary_id'] );
+		$is_scope  = false;
 	} else {
+		$is_scope  = true;
 		$group_ids = cacsp_get_groups_of_user( bp_loggedin_user_id() );
 	}
 
@@ -343,6 +345,11 @@ function cacsp_filter_activity_args_for_groups( $args ) {
 	$args['primary_id'] = '';
 	$args['object'] = '';
 	$args['scope'] = '';
+
+	// Show hidden items if we're using 'groups' activity scope.
+	if ( $is_scope && ! empty( $group_ids ) ) {
+		$args['show_hidden'] = true;
+	}
 
 	return $args;
 }


### PR DESCRIPTION
In Social Paper, we hijack the `'groups'` activity scope to add in group-connected social paper items before wiping out the `'scope'` parameter later:

https://github.com/cuny-academic-commons/social-paper/blob/c6461a16713fe2956549552ea52ee45d814efe67/includes/hooks-buddypress-group.php#L148-L233

When we wipe out the `'scope'` parameter, BuddyPress defaults to not displaying hidden activity items: https://github.com/buddypress/buddypress/blob/39bcd35cf0af2ecc9c0253a0ac3249427e8529c3/src/bp-activity/bp-activity-template.php#L223. So when accessing the "My Groups" tab on the Activity Directory page, hidden group activity items are no longer displayed due to the `'groups'` scope's `'hide_sidewide'` clause no longer being applied: https://github.com/buddypress/buddypress/blob/39bcd35cf0af2ecc9c0253a0ac3249427e8529c3/src/bp-groups/bp-groups-activity.php#L337-L344

This conflicts with other plugins adding hidden group activity items such as BP Event Organiser: https://github.com/cuny-academic-commons/bp-event-organiser/blob/d3bd473b5d72e8a75384f44ae4cde8c5cdf7bc72/includes/group.php#L376-L393. 

To duplicate:

1. Create an event in a public group
2. Go to the Activity Directory page and click on "My Groups" tab
3. The group event's activity item is not displayed

PR adds back the `'show_hidden'` clause when we're using the '`groups'` scope and if the logged-in user has any groups.